### PR TITLE
Upgrade to 5.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ Then in another tab, do:
 
 Changelog
 ------------
-
+* v
+  * Updated to support Solr 5.3.1.
+  * Note that as of Lucene 5.2.0 when synonyms are parsed, original terms are now correctly marked as type `word` instead of type `synonym` [LUCENE-6400](https://issues.apache.org/jira/browse/LUCENE-6400).
 * v1.3.5
   * Added ```synonyms.ignoreMM``` option
 * v1.3.4

--- a/build_all_versions.sh
+++ b/build_all_versions.sh
@@ -7,7 +7,7 @@
 # Writes to directory target/s3
 #
 
-SOLR_VERSIONS='3.x 4.0.0 4.1.0 4.3.0';
+SOLR_VERSIONS='3.x 4.0.0 4.1.0 4.3.0 5.3.1';
 PLUGIN_VERSION=`cat pom.xml | grep version | head -1 | python -c "import re, sys; print re.search('>(.*?)-solr',sys.stdin.read()).group(1)"`
 
 echo -e "\nPlugin version is ${PLUGIN_VERSION}, building for Solr versions ${SOLR_VERSIONS}...\n"

--- a/pom.xml
+++ b/pom.xml
@@ -3,28 +3,58 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.healthonnet.lucene</groupId>
 	<artifactId>hon-lucene-synonyms</artifactId>
-	<version>1.3.5-solr-4.3.0</version>
+	<version>1.3.5-solr-5.3.1</version>
 	<dependencies>
         <dependency>
             <groupId>org.apache.solr</groupId>
-            <artifactId>solr</artifactId>
-            <type>war</type>
-            <version>4.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>4.3.0</version>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>4.3.0</version>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.solr</groupId>
+            <artifactId>solr-test-framework</artifactId>
+            <version>5.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <version>5.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.12</version>
             <scope>test</scope>
         </dependency>
 	</dependencies>
@@ -35,8 +65,8 @@
 	        <artifactId>maven-compiler-plugin</artifactId>
 	        <version>3.0</version>
 	        <configuration>
-	          <source>1.5</source>
-	          <target>1.5</target>
+	          <source>7</source>
+	          <target>7</target>
 	        </configuration>
 	      </plugin>
 	    </plugins>

--- a/run_solr_for_unit_tests.py
+++ b/run_solr_for_unit_tests.py
@@ -72,19 +72,37 @@ solrdir = 'target/webapp/' + tgz_filename
 tar = tarfile.open(local_filename)
 tar.extractall(path='target/webapp/')
 os.mkdir(solrdir + '/example/myjar')
-os.system('cd %s/example/myjar; jar -xf ../webapps/solr.war; cd -' % solrdir)
-os.system('cp target/hon-lucene-synonyms-*.jar %s/example/myjar/WEB-INF/lib' % solrdir)
-os.system('cd %s/example/myjar; jar -cf ../webapps/solr.war *; cd -' % solrdir)
+if version_compare(solr_version, '5.0.0') >= 0:
+  if version_compare(solr_version, '5.3.1') >= 0:
+    os.system('cp target/hon-lucene-synonyms-*.jar %s/server/solr-webapp/webapp/WEB-INF/lib' % solrdir)
+  else:
+    os.system('cd %s/example/myjar; jar -xf ../../server/webapps/solr.war; cd -' % solrdir)
+    os.system('cp target/hon-lucene-synonyms-*.jar %s/example/myjar/WEB-INF/lib' % solrdir)
+    os.system('cd %s/example/myjar; jar -cf ../../server/webapps/solr.war *; cd -' % solrdir)
+else:
+  os.system('cd %s/example/myjar; jar -xf ../webapps/solr.war; cd -' % solrdir)
+  os.system('cp target/hon-lucene-synonyms-*.jar %s/example/myjar/WEB-INF/lib' % solrdir)
+  os.system('cd %s/example/myjar; jar -cf ../webapps/solr.war *; cd -' % solrdir)
 
 # they changed the location of the example conf dir in solr 4.0.0
-confdir = 'collection1/conf' if version_compare(solr_version, '4.0.0') >= 0 else 'conf'
-shutil.copy('examples/example_synonym_file.txt', solrdir + '/example/solr/' + confdir)
+
+if version_compare(solr_version, '5.0.0') >= 0:
+  confdir = 'sample_techproducts_configs/conf'
+  solrexamplepath = '/server/solr/configsets/'
+  shutil.copy('examples/example_synonym_file.txt', solrdir + solrexamplepath + confdir)
+else:
+  if version_compare(solr_version, '4.0.0') >= 0:
+    confdir = 'collection1/conf'
+  else:
+    confdir = 'conf'
+  solrexamplepath = '/example/solr/'
+  shutil.copy('examples/example_synonym_file.txt', solrdir + solrexamplepath + confdir)
 
 # add the config to the config file
 conf_to_add = open('examples/example_config.xml', 'r').read()
 
 
-conf_filename = solrdir + '/example/solr/' + confdir + '/solrconfig.xml'
+conf_filename = solrdir + solrexamplepath + confdir + '/solrconfig.xml'
 filein = open(conf_filename,'r')
 filetext = filein.read()
 filein.close()
@@ -92,9 +110,12 @@ fileout = open(conf_filename,'w')
 fileout.write(filetext.replace('</config>', conf_to_add + '</config>'))
 fileout.close()
 
-debug = ('-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s' % args['--debug-port']) if '--debug' in args else '' 
-cmd = 'cd %(solrdir)s/example; java %(debug)s -Dwhatever=unique_process_id -Djetty.port=%(port)s -jar start.jar' % \
-    {'debug' : debug, 'solrdir' : solrdir, 'port' : args['--port']}
+debug = ('-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s' % args['--debug-port']) if '--debug' in args else ''
+if version_compare(solr_version, '5.0.0') >= 0:
+    cmd = 'cd %(solrdir)s; bin/solr -e techproducts; bin/solr stop; bin/solr start -f -p 8983 -s "example/techproducts/solr"' % {'solrdir': solrdir}
+else:
+  cmd = 'cd %(solrdir)s/example; java %(debug)s -Dwhatever=techproducts -Djetty.port=%(port)s -jar start.jar' % \
+      {'debug' : debug, 'solrdir' : solrdir, 'port' : args['--port']}
 
 print "Running jetty with command: " + cmd
 

--- a/src/test/java/org/apache/solr/search/BasicSynonymExpandingParserTest.java
+++ b/src/test/java/org/apache/solr/search/BasicSynonymExpandingParserTest.java
@@ -1,0 +1,18 @@
+package org.apache.solr.search;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.*;
+
+public class BasicSynonymExpandingParserTest {
+
+    @Test
+    public void test1() throws ClassNotFoundException {
+        Class<?> cast = Class.forName("org.apache.solr.search.QParserPlugin");
+        Class<?> clazz = Class.forName("org.apache.solr.search.SynonymExpandingExtendedDismaxQParserPlugin");
+        
+        assertTrue(cast.isAssignableFrom(clazz));
+        
+    }
+    
+}

--- a/src/test/java/org/apache/solr/search/SynonymExpandingParserTest.java
+++ b/src/test/java/org/apache/solr/search/SynonymExpandingParserTest.java
@@ -1,18 +1,82 @@
 package org.apache.solr.search;
 
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.SimpleOrderedMap;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.apache.solr.util.AbstractSolrTestCase;
+import org.junit.BeforeClass;
+import java.util.ArrayList;
 
-import static junit.framework.Assert.*;
+public class SynonymExpandingParserTest extends AbstractSolrTestCase {
 
-public class SynonymExpandingParserTest {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        initCore("example_solrconfig.xml", "example_schema.xml");
+        assertU(adoc("id", "1", "name", "I have a dog."));
+        assertU(adoc("id", "2", "name", "I have a pooch."));
+        assertU(adoc("id", "3", "name", "I have a hound."));
+        assertU(adoc("id", "4", "name", "I have a canis."));
+        assertU(commit());
+    }
+
+    public void tQuery(String query, int numFound) {
+        SolrQueryRequest request = req("q", query,
+                "fl", "*,score",
+                "qf", "name",
+                "defType", "synonym_edismax",
+                "synonyms", "true",
+                "synonyms.constructPhrases", "true",
+                "debugQuery", "on");
+        assertQuoteCount(request, numFound);
+    }
 
     @Test
-    public void test1() throws ClassNotFoundException {
-        Class<?> cast = Class.forName("org.apache.solr.search.QParserPlugin");
-        Class<?> clazz = Class.forName("org.apache.solr.search.SynonymExpandingExtendedDismaxQParserPlugin");
-        
-        assertTrue(cast.isAssignableFrom(clazz));
-        
+    public void testAllDocsQuery() {
+        /* We have the synonyms:
+        dog, pooch, hound, canis familiaris, man's best friend
+        */
+        tQuery("\"dog\"", 10);
+        tQuery("\"pooch\"", 10);
+        tQuery("\"hound\"", 10);
+        tQuery("\"canis familiaris\"", 10);
+
+        tQuery("dog",4);
+        tQuery("pooch",4);
+        tQuery("hound",4);
+        tQuery("canis familiaris",2);
     }
-    
+
+    @Test
+    @Ignore
+    public void test_issue_51() {
+        /* https://github.com/healthonnet/hon-lucene-synonyms/issues/51
+        */
+        tQuery("canis familiaris",4);
+    }
+
+    /** Validates a query matches some XPath test expressions and closes the query */
+    public static void assertQuoteCount(SolrQueryRequest req, int quoteCount) {
+        try {
+            SolrQueryResponse rsp = h.queryAndResponse("/search",req);
+            SimpleOrderedMap debug = (SimpleOrderedMap)rsp.getValues().get("debug");
+            ArrayList<String> expandedSynonyms = (ArrayList<String>) debug.get("expandedSynonyms");
+            AbstractSolrTestCase.log.info(expandedSynonyms.toString());
+            int count = 0;
+            for (String synonym : expandedSynonyms) {
+                count += synonym.length() - synonym.replace("\"", "").length();
+            }
+            AbstractSolrTestCase.log.info("Quotes found count = " + count);
+            req.close();
+            assertEquals(quoteCount, count);
+        } catch (Exception e2) {
+            req.close();
+            SolrException.log(log,"REQUEST FAILED: " + req.getParamString(), e2);
+            throw new RuntimeException("Exception during query", e2);
+        }
+    }
+
+
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+#  Logging level
+log4j.rootLogger=INFO, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%-4r %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/src/test/resources/solr/collection1/conf/example_schema.xml
+++ b/src/test/resources/solr/collection1/conf/example_schema.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="hon-lucene-synonyms" version="1.5">
+  <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+  <field name="name" type="text_general" indexed="true" stored="true"/>
+  <field name="cat" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="last_modified" type="date" indexed="true" stored="true"/>
+  <uniqueKey>id</uniqueKey>
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
+  <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+  <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+    <analyzer type="index">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+</schema>

--- a/src/test/resources/solr/collection1/conf/example_solrconfig.xml
+++ b/src/test/resources/solr/collection1/conf/example_solrconfig.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- a basic solrconfig that tests can use when they want simple minimal solrconfig/schema
+     DO NOT ADD THINGS TO THIS CONFIG! -->
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+  <dataDir>${solr.data.dir:}</dataDir>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+  <requestHandler name="/search" class="solr.StandardRequestHandler" default="true"></requestHandler>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"></requestHandler>
+
+  <queryParser name="synonym_edismax" class="solr.SynonymExpandingExtendedDismaxQParserPlugin">
+    <!-- You can define more than one synonym analyzer in the following list.
+         For example, you might have one set of synonyms for English, one for French,
+         one for Spanish, etc.
+      -->
+    <lst name="synonymAnalyzers">
+      <!-- Name your analyzer something useful, e.g. "analyzer_en", "analyzer_fr", "analyzer_es", etc.
+           If you only have one, the name doesn't matter (hence "myCoolAnalyzer").
+        -->
+      <lst name="myCoolAnalyzer">
+        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
+             This seems to work best with most people's synonym files.
+             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
+          -->
+        <lst name="tokenizer">
+          <str name="class">solr.PatternTokenizerFactory</str>
+          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
+        </lst>
+        <!-- The ShingleFilterFactory outputs synonyms of multiple token lengths (e.g. unigrams, bigrams, trigrams, etc.).
+             The default here is to assume you don't have any synonyms longer than 4 tokens.
+             You can tweak this depending on what your synonyms look like. E.g. if you only have unigrams, you can remove
+             it entirely, and if your synonyms are up to 7 tokens in length, you should set the maxShingleSize to 7.
+          -->
+        <lst name="filter">
+          <str name="class">solr.ShingleFilterFactory</str>
+          <str name="outputUnigramsIfNoShingles">true</str>
+          <str name="outputUnigrams">true</str>
+          <str name="minShingleSize">2</str>
+          <str name="maxShingleSize">4</str>
+        </lst>
+        <!-- This is where you set your synonym file.  For the unit tests and "Getting Started" examples, we use example_synonym_file.txt.
+             This plugin will work best if you keep expand set to true and have all your synonyms comma-separated (rather than =>-separated).
+          -->
+        <lst name="filter">
+          <str name="class">solr.SynonymFilterFactory</str>
+          <str name="tokenizerFactory">solr.KeywordTokenizerFactory</str>
+          <str name="synonyms">example_synonym_file.txt</str>
+          <str name="expand">true</str>
+          <str name="ignoreCase">true</str>
+        </lst>
+      </lst>
+    </lst>
+  </queryParser>
+</config>

--- a/src/test/resources/solr/collection1/conf/example_synonym_file.txt
+++ b/src/test/resources/solr/collection1/conf/example_synonym_file.txt
@@ -1,0 +1,15 @@
+dog,hound,pooch,canis familiaris,man's best friend
+back pack=>backpack
+
+# issue 32
+e-commerce,electronic commerce
+
+# issues 9 and 26
+bfo, brystforstørrende operation
+血と骨,Blood and Bones
+
+# issue 29
+Swedish turnips, rutabagas
+
+# issue 31 - need two and only two single-word synonyms
+jigglypuff, purin

--- a/test.sh
+++ b/test.sh
@@ -3,9 +3,9 @@
 ./run_solr_for_unit_tests.py &
 SOLR_PID=$!
 
-while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:8983/solr/) != '200' ]]; do
-  echo "waiting for localhost:8983 to be available..."
-  sleep 10;
+while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:8983/solr/techproducts/admin/file/?file=admin-extra.html) != '200' ]]; do
+  echo "waiting for "techproducts" at localhost:8983 to be available..."
+  sleep 20;
 done
 
 echo "localhost:8983 is available"

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ SOLR_PID=$!
 
 while [[ $(curl -s -o /dev/null -w '%{http_code}' http://localhost:8983/solr/) != '200' ]]; do
   echo "waiting for localhost:8983 to be available..."
-  sleep 1;
+  sleep 10;
 done
 
 echo "localhost:8983 is available"
@@ -18,7 +18,7 @@ if [[ ! -z $SOLR_PID ]]; then
   echo "killing solr..."
   kill -INT $SOLR_PID
   # couldn't figure out any better way to kill the java subprocess
-  kill `ps -ef | grep unique_process_id | grep -v grep | awk '{print $2}'`
+  kill `ps -ef | grep techproducts | grep -v grep | awk '{print $2}'`
 fi
 
 exit $EXIT_CODE

--- a/test/001-test-synonyms-basic.py
+++ b/test/001-test-synonyms-basic.py
@@ -6,6 +6,7 @@
 #
 
 import unittest, solr
+from lib import connection_with_core
 
 class TestBasic(unittest.TestCase):
     
@@ -20,10 +21,11 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection('http://localhost:8983/solr')
+        self.solr_connection = connection_with_core(solr.SolrConnection('http://localhost:8983/solr'))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()
+
     def tearDown(self):
         self.solr_connection.delete_query('*:*')
         self.solr_connection.commit()

--- a/test/002-test-phrases.py
+++ b/test/002-test-phrases.py
@@ -6,6 +6,7 @@
 #
 
 import unittest, solr, urllib
+from lib import connection_with_core
 
 class TestBasic(unittest.TestCase):
     
@@ -26,7 +27,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/003-test-phrase-slop.py
+++ b/test/003-test-phrase-slop.py
@@ -5,7 +5,12 @@
 # described in the "Getting Started" section of the readme.
 #
 
-import unittest, solr, urllib,time
+import solr
+import unittest
+import urllib
+
+from lib import connection_with_core
+
 
 class TestBasic(unittest.TestCase):
     
@@ -18,7 +23,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/004-test-constructed-phrases.py
+++ b/test/004-test-constructed-phrases.py
@@ -5,7 +5,13 @@
 # described in the "Getting Started" section of the readme.
 #
 
-import unittest, solr, urllib
+import solr
+import unittest
+import urllib
+
+
+from lib import connection_with_core
+
 
 class TestBasic(unittest.TestCase):
     
@@ -19,7 +25,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/005-test-constructed-phrases.py
+++ b/test/005-test-constructed-phrases.py
@@ -7,6 +7,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -19,7 +21,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/006-test-bag-expand.py
+++ b/test/006-test-bag-expand.py
@@ -7,6 +7,8 @@
 
 import unittest, solr
 
+from lib import connection_with_core
+
 class TestBaggedSynonyms(unittest.TestCase):
     
     test_data = [
@@ -20,7 +22,7 @@ class TestBaggedSynonyms(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection('http://localhost:8983/solr')
+        self.solr_connection = connection_with_core(solr.SolrConnection('http://localhost:8983/solr'))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/007-test-query-operators.py
+++ b/test/007-test-query-operators.py
@@ -6,6 +6,8 @@
 
 import unittest, solr, urllib
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -16,7 +18,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/008-test-utf8.py
+++ b/test/008-test-utf8.py
@@ -6,6 +6,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -18,7 +20,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/009-test-issue-29.py
+++ b/test/009-test-issue-29.py
@@ -4,6 +4,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -15,7 +17,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/010-test-issue-31.py
+++ b/test/010-test-issue-31.py
@@ -4,6 +4,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -24,7 +26,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/011-test-highlighting.py
+++ b/test/011-test-highlighting.py
@@ -4,6 +4,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -13,7 +15,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/012-test-ranking.py
+++ b/test/012-test-ranking.py
@@ -8,6 +8,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     url = 'http://localhost:8983/solr'
@@ -21,7 +23,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/013-test-issue-33.py
+++ b/test/013-test-issue-33.py
@@ -6,6 +6,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     #
@@ -30,7 +32,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/014-test-issue-34.py
+++ b/test/014-test-issue-34.py
@@ -6,6 +6,8 @@
 
 import unittest, solr, urllib, time
 
+from lib import connection_with_core
+
 class TestBasic(unittest.TestCase):
     
     #
@@ -24,7 +26,7 @@ class TestBasic(unittest.TestCase):
     solr_connection = None
     
     def setUp(self):
-        self.solr_connection = solr.SolrConnection(self.url)
+        self.solr_connection = connection_with_core(solr.SolrConnection(self.url))
         self.solr_connection.delete_query('*:*')
         self.solr_connection.add_many(self.test_data)
         self.solr_connection.commit()

--- a/test/lib/__init__.py
+++ b/test/lib/__init__.py
@@ -1,0 +1,13 @@
+import solr
+import json
+
+
+def first_core_of_connection(solr_connection):
+    response = solr.SearchHandler(solr_connection, "/admin/cores").raw(**{'action': 'STATUS', 'wt': 'json'})
+    results = json.loads(response)
+    core = results['status'].keys().pop()
+    return core
+
+
+def connection_with_core(solr_connection):
+    return solr.SolrConnection('http://localhost:8983/solr/{}'.format(first_core_of_connection(solr_connection)))


### PR DESCRIPTION
Rebased version of #53 to ensure that tests are passing in Travis. I had to fiddle with my hack to check for processes with the key `techproducts`.

If Travis is passing, then I'm +1. I'm also +1 to just stop supporting older versions of Solr, because it's not practical anymore. I don't have the time to maintain multiple branches and test them all.