### PR TITLE
Reason for not expanding in case of hasComplexQueryOperators is misleading.

### DIFF
--- a/src/main/java/org/apache/solr/synonyms/ReasonForNotExpandingSynonyms.java
+++ b/src/main/java/org/apache/solr/synonyms/ReasonForNotExpandingSynonyms.java
@@ -30,8 +30,8 @@ public enum ReasonForNotExpandingSynonyms {
     AnalyzerNotFound("There's no analyzer with the name you specified in synonyms.analyzer."),
     IgnoringPhrases("synonyms.disablePhraseQueries is set to true, and this query contains a phrase (\"like this\")"),
     UnhandledException("Whoops, we ran into an exception we couldn't handle!  File a bug."),
-    HasComplexQueryOperators("synonyms.ignoreQueryOperators is set to true, and this query contains complex query "
-            + "operators (e.g. AND, OR, *, -, etc.)"),
+    HasComplexQueryOperators("synonyms.ignoreQueryOperators is set to false, and this query contains complex query "
+            + "operators (e.g. AND, OR, *, -, etc.). Complex queries aren't supported."),
     DidntFindAnySynonyms("No synonyms found for this query.  Check your synonyms file."),
     ;
     


### PR DESCRIPTION
HasComplexQueryOperators is encountered when the ignoreQueryOperators is **false** and the query contains complex operators: https://github.com/healthonnet/hon-lucene-synonyms/blob/master/src/main/java/org/apache/solr/search/SynonymExpandingExtendedDismaxQParserPlugin.java#L375

I was working on this and this misleading comment took quite a lot of my time. We should fix this.
