### PR TITLE
Add a preanalyzis of the original request before sending to edismax parsers

### DIFF
--- a/hon-lucene-synonyms.iml
+++ b/hon-lucene-synonyms.iml
@@ -11,25 +11,25 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.apache.solr:solr-core:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-common:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-kuromoji:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-phonetic:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-backward-codecs:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-classification:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-codecs:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-core:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-expressions:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-grouping:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-highlighter:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-join:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-memory:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-misc:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-queries:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-queryparser:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-sandbox:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-spatial-extras:6.2.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-suggest:6.2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.solr:solr-core:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-common:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-kuromoji:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-analyzers-phonetic:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-backward-codecs:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-classification:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-codecs:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-core:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-expressions:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-grouping:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-highlighter:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-join:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-memory:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-misc:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-queries:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-queryparser:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-sandbox:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-spatial-extras:6.4.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.lucene:lucene-suggest:6.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.carrotsearch:hppc:0.7.1" level="project" />
     <orderEntry type="library" name="Maven: com.facebook.presto:presto-parser:0.122" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.5.4" level="project" />
@@ -94,16 +94,16 @@
     <orderEntry type="library" name="Maven: org.ow2.asm:asm-commons:5.1" level="project" />
     <orderEntry type="library" name="Maven: org.restlet.jee:org.restlet:2.3.0" level="project" />
     <orderEntry type="library" name="Maven: org.restlet.jee:org.restlet.ext.servlet:2.3.0" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.solr:solr-solrj:6.2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.solr:solr-solrj:6.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.5.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.5.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apache.solr:solr-test-framework:6.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.solr:solr-test-framework:6.4.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.carrotsearch.randomizedtesting:junit4-ant:2.3.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.3.4" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.ant:ant:1.8.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apache.lucene:lucene-test-framework:6.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apache.lucene:lucene-test-framework:6.4.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-api:1.7.7" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:jcl-over-slf4j:1.7.7" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:jul-to-slf4j:1.7.7" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,6 @@
     <developerConnection>scm:git:git@github.com:healthonnet/hon-lucene-synonyms.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
   <description>Enables proper query-time synonym expansion, with no reindexing required.</description>
   <developers>
     <developer>
@@ -51,7 +45,7 @@
   </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <solr.version>6.2.0</solr.version>
+    <solr.version>6.4.2</solr.version>
     <slf4j.version>1.7.7</slf4j.version>
   </properties>
 	<dependencies>
@@ -172,4 +166,33 @@
         </plugin>
 	    </plugins>
 	  </build>
+	  
+	  <profiles>
+	  
+        <profile>
+            <id>jouve</id>
+            <distributionManagement>
+                <!-- use the following if you're not using a snapshot version. -->
+                <repository>
+                    <id>jouve-releases</id>
+                    <url>http://nexus-master-si.jouve.local/nexus/content/repositories/releases</url>
+                </repository>
+                <!-- use the following if you ARE using a snapshot version. -->
+                <snapshotRepository>
+                    <id>jouve-snapshots</id>
+                    <url>http://nexus-master-si.jouve.local/nexus/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+        <profile>
+ 		  <id>ossrh</id>
+          <distributionManagement>
+			    <snapshotRepository>
+			      <id>ossrh</id>
+			      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			    </snapshotRepository>
+  		   </distributionManagement>
+          </profile>
+ 
+	  </profiles>	  
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.healthonnet</groupId>
 	<artifactId>hon-lucene-synonyms</artifactId>
-	<version>5.0.6-SNAPSHOT</version>
+	<version>5.0.7-SNAPSHOT</version>
   <name>HON Lucene Synonyms</name>
   <url>https://github.com/healthonnet/hon-lucene-synonyms</url>
   <issueManagement>
@@ -45,7 +45,7 @@
   </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <solr.version>6.4.2</solr.version>
+    <solr.version>6.4.1</solr.version>
     <slf4j.version>1.7.7</slf4j.version>
   </properties>
 	<dependencies>

--- a/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
+++ b/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
@@ -20,9 +20,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +30,6 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import com.github.healthonnet.synonyms.AlternateQuery;
-import com.github.healthonnet.synonyms.ReasonForNotExpandingSynonyms;
-import com.github.healthonnet.synonyms.TextInQuery;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
@@ -59,56 +56,51 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.search.ExtendedDismaxQParser;
 import org.apache.solr.search.QParser;
 import org.apache.solr.search.QParserPlugin;
+import org.apache.solr.search.SyntaxError;
+
 import com.github.healthonnet.search.SynonymExpandingExtendedDismaxQParserPlugin.Const;
 import com.github.healthonnet.search.SynonymExpandingExtendedDismaxQParserPlugin.Params;
-import org.apache.solr.search.SyntaxError;
+import com.github.healthonnet.synonyms.AlternateQuery;
 import com.github.healthonnet.synonyms.NoBoostSolrParams;
-
+import com.github.healthonnet.synonyms.ReasonForNotExpandingSynonyms;
+import com.github.healthonnet.synonyms.TextInQuery;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 
 /**
- * 
- * Main implementation of the synonym-expanding ExtendedDismaxQParser plugin for Solr.
- * 
- * This parser was originally derived from ExtendedDismaxQParser, which itself was derived from the 
- * DismaxQParser from Solr.
+ * Main implementation of the synonym-expanding ExtendedDismaxQParser plugin for Solr. This parser was originally derived from ExtendedDismaxQParser, which itself was derived from the DismaxQParser from Solr.
  * 
  * @see <a href="https://github.com/healthonnet/hon-lucene-synonyms">https://github.com/healthonnet/hon-lucene-synonyms</a>
  */
-public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin implements
-        ResourceLoaderAware {
+public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin implements ResourceLoaderAware {
     public static final String name = "synonym_edismax";
 
     /**
      * Convenience class for parameters
      */
     public static class Params {
-        
+
         /**
          * @see <a href="https://cwiki.apache.org/confluence/display/solr/The+Extended+DisMax+Query+Parser">The Extended DisMax Query Parser</a>
          */
         public static String MULT_BOOST = "boost";
-        
+
         public static final String SYNONYMS = "synonyms";
         public static final String SYNONYMS_ANALYZER = "synonyms.analyzer";
+        public static final String SYNONYMS_DEFAULT_ANALYZER = "synonyms.default";
         public static final String SYNONYMS_ORIGINAL_BOOST = "synonyms.originalBoost";
         public static final String SYNONYMS_SYNONYM_BOOST = "synonyms.synonymBoost";
         public static final String SYNONYMS_DISABLE_PHRASE_QUERIES = "synonyms.disablePhraseQueries";
         public static final String SYNONYMS_CONSTRUCT_PHRASES = "synonyms.constructPhrases";
         public static final String SYNONYMS_IGNORE_QUERY_OPERATORS = "synonyms.ignoreQueryOperators";
-        /** 
-         * instead of splicing synonyms into the original query string, ie
-         *    dog bite
-         *    canine familiaris bite
-         *    dog chomp
-         *    canine familiaris chomp
-         * do this: 
-         *    dog bite 
-         *    "canine familiaris" chomp
-         * with phrases off:
-         *    dog bite canine familiaris chomp
+
+        public static final String MAIN_PREANALYZIS = "synonyms.preanalyzis";
+        public static final String MAIN_ANALYZER = "synonyms.preanalyzer";
+        public static final String MAIN_DEFAULT_ANALYZER = "synonyms.defaultPreanalyzer";
+
+        /**
+         * instead of splicing synonyms into the original query string, ie dog bite canine familiaris bite dog chomp canine familiaris chomp do this: dog bite "canine familiaris" chomp with phrases off: dog bite canine familiaris chomp
          */
         public static final String SYNONYMS_BAG = "synonyms.bag";
 
@@ -122,72 +114,74 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
 
     /**
      * Convenience class for calling constants.
+     * 
      * @author nolan
-     *
      */
     public static class Const {
         /**
-         * A field we can't ever find in any schema, so we can safely tell
-         * DisjunctionMaxQueryParser to use it as our defaultField, and map aliases
-         * from it to any field in our schema.
+         * A field we can't ever find in any schema, so we can safely tell DisjunctionMaxQueryParser to use it as our defaultField, and map aliases from it to any field in our schema.
          */
         static final String IMPOSSIBLE_FIELD_NAME = "\uFFFC\uFFFC\uFFFC";
-        
-        static final Pattern COMPLEX_QUERY_OPERATORS_PATTERN = Pattern.compile("(?:\\*|\\s-\\b|\\b(?:OR|AND|\\+)\\b)"); 
-    }    
-    
+
+        static final Pattern COMPLEX_QUERY_OPERATORS_PATTERN = Pattern.compile("(?:\\*|\\s-\\b|\\b(?:OR|AND|\\+)\\b)");
+    }
+
     private NamedList<?> args;
     private Map<String, Analyzer> synonymAnalyzers;
+    private Map<String, Analyzer> mainAnalyzers;
     private Version luceneMatchVersion = null;
     private SolrResourceLoader loader;
 
+    @Override
     @SuppressWarnings("rawtypes")
     // TODO it would be nice if the user didn't have to encode tokenizers/filters
-    // as a NamedList.  But for now this is the hack I'm using
+    // as a NamedList. But for now this is the hack I'm using
     public void init(NamedList args) {
-        this.args = (NamedList<?>)args;
+        this.args = args;
     }
 
     @Override
     public QParser createParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req) {
         if (luceneMatchVersion == null) {
             this.luceneMatchVersion = req.getCore().getSolrConfig().luceneMatchVersion;
-            parseConfig();
+            synonymAnalyzers = new HashMap<>();
+            parseConfig(synonymAnalyzers, "synonymAnalyzers");
+            mainAnalyzers = new HashMap<>();
+            parseConfig(mainAnalyzers, "queryAnalyzers");
+
         }
-        return new SynonymExpandingExtendedDismaxQParser(qstr, localParams, params, req, synonymAnalyzers);
+        return new SynonymExpandingExtendedDismaxQParser(qstr, localParams, params, req, synonymAnalyzers, mainAnalyzers);
     }
-    
+
     private Map<String, String> convertNamedListToMap(NamedList<?> namedList) {
         Map<String, String> result = new HashMap<>();
-        
+
         for (Entry<String, ?> entry : namedList) {
             if (entry.getValue() instanceof String) {
-                result.put(entry.getKey(), (String)entry.getValue());
+                result.put(entry.getKey(), (String) entry.getValue());
             }
         }
-        
+
         return result;
     }
 
+    @Override
     public void inform(ResourceLoader loader) throws IOException {
         // TODO: Can we assume that loader always is a sub type of SolrResourceLoader?
         this.loader = (SolrResourceLoader) loader;
     }
 
     /*
-     * Expected call pattern:
-     * init(), inform(loader), createParser(), so we should now have
-     * config, loader and luceneMatchVersion needed for creating analyzer components
+     * Expected call pattern: init(), inform(loader), createParser(), so we should now have config, loader and luceneMatchVersion needed for creating analyzer components
      */
-    private void parseConfig() {
+    private void parseConfig(Map<String, Analyzer> analyzers, String argName) {
         try {
-            synonymAnalyzers = new HashMap<>();
 
-            Object xmlSynonymAnalyzers = args.get("synonymAnalyzers");
+            Object xmlAnalyzers = args.get(argName);
 
-            if (xmlSynonymAnalyzers != null && xmlSynonymAnalyzers instanceof NamedList) {
-                NamedList<?> synonymAnalyzersList = (NamedList<?>) xmlSynonymAnalyzers;
-                for (Entry<String, ?> entry : synonymAnalyzersList) {
+            if (xmlAnalyzers != null && xmlAnalyzers instanceof NamedList) {
+                NamedList<?> AnalyzersList = (NamedList<?>) xmlAnalyzers;
+                for (Entry<String, ?> entry : AnalyzersList) {
                     String analyzerName = entry.getKey();
                     if (!(entry.getValue() instanceof NamedList)) {
                         continue;
@@ -203,7 +197,7 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
                         if (!(entry.getValue() instanceof NamedList)) {
                             continue;
                         }
-                        Map<String, String> params = convertNamedListToMap((NamedList<?>)analyzerEntry.getValue());
+                        Map<String, String> params = convertNamedListToMap((NamedList<?>) analyzerEntry.getValue());
 
                         String className = params.get("class");
                         if (className == null) {
@@ -220,10 +214,10 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
                                     iae.printStackTrace();
                                 }
                                 // Now try by classname instead of SPI keyword
-                                tokenizerFactory = loader.newInstance(className, TokenizerFactory.class, new String[]{}, new Class[] { Map.class }, new Object[] { params });
+                                tokenizerFactory = loader.newInstance(className, TokenizerFactory.class, new String[] {}, new Class[] { Map.class }, new Object[] { params });
                             }
                             if (tokenizerFactory instanceof ResourceLoaderAware) {
-                                ((ResourceLoaderAware)tokenizerFactory).inform(loader);
+                                ((ResourceLoaderAware) tokenizerFactory).inform(loader);
                             }
                         } else if (key.equals("filter")) {
                             try {
@@ -233,26 +227,23 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
                                     iae.printStackTrace();
                                 }
                                 // Now try by classname instead of SPI keyword
-                                filterFactory = loader.newInstance(className, TokenFilterFactory.class, new String[]{}, new Class[] { Map.class }, new Object[] { params });
+                                filterFactory = loader.newInstance(className, TokenFilterFactory.class, new String[] {}, new Class[] { Map.class }, new Object[] { params });
                             }
                             if (filterFactory instanceof ResourceLoaderAware) {
-                                ((ResourceLoaderAware)filterFactory).inform(loader);
+                                ((ResourceLoaderAware) filterFactory).inform(loader);
                             }
                             filterFactories.add(filterFactory);
                         }
                     }
                     if (tokenizerFactory == null) {
-                        throw new SolrException(ErrorCode.SERVER_ERROR,
-                                "tokenizer must not be null for synonym analyzer: " + analyzerName);
+                        throw new SolrException(ErrorCode.SERVER_ERROR, "tokenizer must not be null for analyzer: " + analyzerName);
                     } else if (filterFactories.isEmpty()) {
-                        throw new SolrException(ErrorCode.SERVER_ERROR,
-                                "filter factories must be defined for synonym analyzer: " + analyzerName);
+                        throw new SolrException(ErrorCode.SERVER_ERROR, "filter factories must be defined for analyzer: " + analyzerName);
                     }
 
-                    TokenizerChain analyzer = new TokenizerChain(tokenizerFactory,
-                            filterFactories.toArray(new TokenFilterFactory[filterFactories.size()]));
+                    TokenizerChain analyzer = new TokenizerChain(tokenizerFactory, filterFactories.toArray(new TokenFilterFactory[filterFactories.size()]));
 
-                    synonymAnalyzers.put(analyzerName, analyzer);
+                    analyzers.put(analyzerName, analyzer);
                 }
             }
         } catch (IOException e) {
@@ -268,35 +259,38 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
     private ExtendedDismaxQParser mainQueryParser;
 
     private Map<String, Analyzer> synonymAnalyzers;
+    private Map<String, Analyzer> mainAnalyzers;
+    private Analyzer mainAnalyzer = null;
     private Query queryToHighlight;
-    
+
     /**
      * variables used purely for debugging
      */
     private List<String> expandedSynonyms;
     private ReasonForNotExpandingSynonyms reasonForNotExpandingSynonyms;
-    
-    public SynonymExpandingExtendedDismaxQParser(String qstr, SolrParams localParams, SolrParams params,
-            SolrQueryRequest req, Map<String, Analyzer> synonymAnalyzers) {
+    private String parsedQuery = null;
+    private String originalQuery = null;
+
+    public SynonymExpandingExtendedDismaxQParser(String qstr, SolrParams localParams, SolrParams params, SolrQueryRequest req, Map<String, Analyzer> synonymAnalyzers, Map<String, Analyzer> mainAnalyzers) {
         super(qstr, localParams, params, req);
         mainQueryParser = new ExtendedDismaxQParser(qstr, localParams, params, req);
-        
+        originalQuery = qstr;
         // ensure the synonyms aren't artificially boosted
-        synonymQueryParser = new ExtendedDismaxQParser(qstr, NoBoostSolrParams.wrap(localParams),
-                NoBoostSolrParams.wrap(params), req);
+        synonymQueryParser = new ExtendedDismaxQParser(qstr, NoBoostSolrParams.wrap(localParams), NoBoostSolrParams.wrap(params), req);
         this.synonymAnalyzers = synonymAnalyzers;
+        this.mainAnalyzers = mainAnalyzers;
     }
 
     @Override
     public String[] getDefaultHighlightFields() {
-      return mainQueryParser.getDefaultHighlightFields();
+        return mainQueryParser.getDefaultHighlightFields();
     }
-    
+
     @Override
     public Query getHighlightQuery() throws SyntaxError {
         return queryToHighlight != null ? queryToHighlight : mainQueryParser.getHighlightQuery();
     }
-    
+
     @Override
     public void addDebugInfo(NamedList<Object> debugInfo) {
         if (queryToHighlight != null) {
@@ -308,46 +302,82 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
         if (reasonForNotExpandingSynonyms != null) {
             debugInfo.add("reasonForNotExpandingSynonyms", reasonForNotExpandingSynonyms.toNamedList());
         }
+        debugInfo.add("originalQuery", originalQuery);
+        if (parsedQuery != null)
+            debugInfo.add("originalPreparsedQuery", parsedQuery);
         debugInfo.add("mainQueryParser", createDebugInfo(mainQueryParser));
         debugInfo.add("synonymQueryParser", createDebugInfo(synonymQueryParser));
     }
-    
 
     @Override
     public Query parse() throws SyntaxError {
-        Query query = mainQueryParser.parse();
 
         SolrParams localParams = getLocalParams();
         SolrParams params = getParams();
         SolrParams solrParams = localParams == null ? params : SolrParams.wrapDefaults(localParams, params);
+
+        String defmainAnalyser = solrParams.get(Params.MAIN_DEFAULT_ANALYZER, null);
+        String defSynonymsAnalyser = solrParams.get(Params.SYNONYMS_DEFAULT_ANALYZER, null);
+
+        Boolean preanalyzis = solrParams.getBool(Params.MAIN_PREANALYZIS, false);
+
+        // check to make sure the analyzer exists
+        if (preanalyzis) {
+            String preAnalyzerName = solrParams.get(Params.MAIN_ANALYZER, null);
+            if (preAnalyzerName == null) { // no query analyzer specified
+                if (defmainAnalyser != null && defmainAnalyser.length() > 0) {
+                    preAnalyzerName = defmainAnalyser;
+                } else {
+                    if (mainAnalyzers.size() >= 1) {
+                        // only one analyzer defined; just use that one
+                        preAnalyzerName = mainAnalyzers.keySet().iterator().next();
+                    }
+                }
+            }
+
+            if (preAnalyzerName != null) {
+
+                mainAnalyzer = mainAnalyzers.get(preAnalyzerName);
+
+                analyzeMainQuery(mainAnalyzer);
+            } else
+                mainAnalyzer = null;
+        } else {
+            mainAnalyzer = null;
+        }
+
+        Query query = mainQueryParser.parse();
 
         // disable/enable synonym handling altogether
         if (!solrParams.getBool(Params.SYNONYMS, false)) {
             reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.PluginDisabled;
             return query;
         }
-        
+
         // check to make sure the analyzer exists
         String analyzerName = solrParams.get(Params.SYNONYMS_ANALYZER, null);
         if (analyzerName == null) { // no synonym analyzer specified
-            if (synonymAnalyzers.size() == 1) {
-                // only one analyzer defined; just use that one
-                analyzerName = synonymAnalyzers.keySet().iterator().next();
+            if (defSynonymsAnalyser != null && defSynonymsAnalyser.length() > 0) {
+                analyzerName = defSynonymsAnalyser;
             } else {
-                reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.NoAnalyzerSpecified;
-                return query;
+                if (synonymAnalyzers.size() >= 1) {
+                    // only one analyzer defined; just use that one
+                    analyzerName = synonymAnalyzers.keySet().iterator().next();
+                } else {
+                    reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.NoAnalyzerSpecified;
+                    return query;
+                }
             }
         }
-        
+
         Analyzer synonymAnalyzer = synonymAnalyzers.get(analyzerName);
-        
+
         if (synonymAnalyzer == null) { // couldn't find analyzer
             reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.AnalyzerNotFound;
             return query;
         }
-        
-        if (solrParams.getBool(Params.SYNONYMS_DISABLE_PHRASE_QUERIES, false)
-                && getQueryStringFromParser().indexOf('"') != -1) {
+
+        if (solrParams.getBool(Params.SYNONYMS_DISABLE_PHRASE_QUERIES, false) && getQueryStringFromParser().indexOf('"') != -1) {
             // disable if a phrase query is detected, i.e. there's a '"'
             reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.IgnoringPhrases;
             return query;
@@ -364,13 +394,59 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
         return query;
     }
 
+    private void analyzeMainQuery(Analyzer analyzer) {
+
+        String newQuery = analyzeQuery(getString(), analyzer);
+
+        parsedQuery = newQuery;
+        this.mainQueryParser.setString(newQuery);
+        this.synonymQueryParser.setString(newQuery);
+        this.setString(newQuery);
+
+    }
+
+    private String analyzeQuery(String query, Analyzer analyzer) {
+
+        if (analyzer != null && query != null && query.length() > 0) {
+            TokenStream tokenStream = analyzer.tokenStream(Const.IMPOSSIBLE_FIELD_NAME, new StringReader(query));
+
+            StringBuilder newQueryB = new StringBuilder();
+            try {
+                tokenStream.reset();
+                while (tokenStream.incrementToken()) {
+                    CharTermAttribute term = tokenStream.getAttribute(CharTermAttribute.class);
+                    // OffsetAttribute offsetAttribute = tokenStream.getAttribute(OffsetAttribute.class);
+                    // TypeAttribute typeAttribute = tokenStream.getAttribute(TypeAttribute.class);
+
+                    newQueryB.append(term.toString());
+                    newQueryB.append(' ');
+
+                }
+                tokenStream.end();
+                return newQueryB.toString().trim();
+
+            } catch (IOException e) {
+                throw new RuntimeException("uncaught exception in synonym processing", e);
+            } finally {
+                try {
+                    tokenStream.close();
+                } catch (IOException e) {
+                    throw new RuntimeException("uncaught exception in synonym processing", e);
+                }
+            }
+        }
+
+        return query;
+
+    }
+
     private Query attemptToApplySynonymsToQuery(Query query, SolrParams solrParams, Analyzer synonymAnalyzer) throws IOException {
-        
+
         List<Query> synonymQueries = generateSynonymQueries(synonymAnalyzer, solrParams);
-        
+
         boolean ignoreQueryOperators = solrParams.getBool(Params.SYNONYMS_IGNORE_QUERY_OPERATORS, false);
         boolean hasComplexQueryOperators = ignoreQueryOperators ? false : Const.COMPLEX_QUERY_OPERATORS_PATTERN.matcher(getQueryStringFromParser()).find();
-        
+
         if (hasComplexQueryOperators) { // TODO: support complex operators
             reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.HasComplexQueryOperators;
             return query;
@@ -378,20 +454,17 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
             reasonForNotExpandingSynonyms = ReasonForNotExpandingSynonyms.DidntFindAnySynonyms;
             return query;
         }
-        
+
         float originalBoost = solrParams.getFloat(Params.SYNONYMS_ORIGINAL_BOOST, 1.0F);
         float synonymBoost = solrParams.getFloat(Params.SYNONYMS_SYNONYM_BOOST, 1.0F);
-        
+
         query = applySynonymQueries(query, synonymQueries, originalBoost, synonymBoost);
         return query;
     }
 
     /**
-     * Find the main query and its surrounding clause, make it SHOULD instead of MUST and append a bunch
-     * of other SHOULDs to it, then wrap it in a MUST
+     * Find the main query and its surrounding clause, make it SHOULD instead of MUST and append a bunch of other SHOULDs to it, then wrap it in a MUST E.g. +(text:dog) becomes +((text:dog)^1.5 ((text:hound) (text:pooch))^1.2)
      * 
-     * E.g. +(text:dog) becomes
-     * +((text:dog)^1.5 ((text:hound) (text:pooch))^1.2)
      * @param query
      * @param synonymQueries
      * @param originalBoost
@@ -407,11 +480,13 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
                     BooleanQuery.Builder combinedQueryBuilder = new BooleanQuery.Builder();
                     combinedQueryBuilder.add(new BoostQuery(booleanClause.getQuery(), originalBoost), Occur.SHOULD);
                     // standard 'must occur' clause - i.e. the main user query
-                    
+
                     for (Query synonymQuery : synonymQueries) {
-                        BooleanQuery.Builder booleanSynonymQueryBuilder = new BooleanQuery.Builder();
-                        booleanSynonymQueryBuilder.add(new BoostQuery(synonymQuery, synonymBoost), Occur.SHOULD);
-                        combinedQueryBuilder.add(booleanSynonymQueryBuilder.build(), Occur.SHOULD);
+                        if (synonymQuery != null) {
+                            BooleanQuery.Builder booleanSynonymQueryBuilder = new BooleanQuery.Builder();
+                            booleanSynonymQueryBuilder.add(new BoostQuery(synonymQuery, synonymBoost), Occur.SHOULD);
+                            combinedQueryBuilder.add(booleanSynonymQueryBuilder.build(), Occur.SHOULD);
+                        }
                     }
                     booleanQueryBuilder.add(combinedQueryBuilder.build(), Occur.MUST);
                 } else {
@@ -426,66 +501,57 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
 
     /**
      * Given the synonymAnalyzer, returns a list of all alternate queries expanded from the original user query.
+     * 
      * @param synonymAnalyzer
      * @param solrParams
      * @return
      */
     private List<Query> generateSynonymQueries(Analyzer synonymAnalyzer, SolrParams solrParams) {
 
-	String origQuery = getQueryStringFromParser();
-	int queryLen = origQuery.length();
-	
+        String origQuery = getQueryStringFromParser();
+        int queryLen = origQuery.length();
+
         // TODO: make the token stream reusable?
-        TokenStream tokenStream = synonymAnalyzer.tokenStream(Const.IMPOSSIBLE_FIELD_NAME,
-                new StringReader(origQuery));
-        
+        TokenStream tokenStream = synonymAnalyzer.tokenStream(Const.IMPOSSIBLE_FIELD_NAME, new StringReader(origQuery));
+
         SortedSetMultimap<Integer, TextInQuery> startPosToTextsInQuery = TreeMultimap.create();
-        
-        
+
         boolean constructPhraseQueries = solrParams.getBool(Params.SYNONYMS_CONSTRUCT_PHRASES, false);
-        
+
         boolean bag = solrParams.getBool(Params.SYNONYMS_BAG, false);
         List<String> synonymBag = new ArrayList<>();
-        
+
         try {
             tokenStream.reset();
             while (tokenStream.incrementToken()) {
                 CharTermAttribute term = tokenStream.getAttribute(CharTermAttribute.class);
                 OffsetAttribute offsetAttribute = tokenStream.getAttribute(OffsetAttribute.class);
                 TypeAttribute typeAttribute = tokenStream.getAttribute(TypeAttribute.class);
-                
+
                 if (!typeAttribute.type().equals("shingle")) {
                     // ignore shingles; we only care about synonyms and the original text
                     // TODO: filter other types as well
-                    
+
                     String termToAdd = term.toString();
-                    
+
                     if (typeAttribute.type().equals("SYNONYM")) {
-                        synonymBag.add(termToAdd);                    	
+                        synonymBag.add(termToAdd);
                     }
-                    
-                    //Don't quote sibgle term term synonyms
-		    if (constructPhraseQueries && typeAttribute.type().equals("SYNONYM") &&
-			termToAdd.contains(" ")) 
-		    {
-		    	//Don't Quote when original is already surrounded by quotes
-		    	if( offsetAttribute.startOffset()==0 || 
-		    	    offsetAttribute.endOffset() == queryLen ||
-		    	    origQuery.charAt(offsetAttribute.startOffset()-1)!='"' || 
-		    	    origQuery.charAt(offsetAttribute.endOffset())!='"')
-		    	{
-		    	    // make a phrase out of the synonym
-		    	    termToAdd = new StringBuilder(termToAdd).insert(0,'"').append('"').toString();
-		    	}
-		    }
+
+                    // Don't quote sibgle term term synonyms
+                    if (constructPhraseQueries && typeAttribute.type().equals("SYNONYM") && termToAdd.contains(" ")) {
+                        // Don't Quote when original is already surrounded by quotes
+                        if (offsetAttribute.startOffset() == 0 || offsetAttribute.endOffset() == queryLen || origQuery.charAt(offsetAttribute.startOffset() - 1) != '"' || origQuery.charAt(offsetAttribute.endOffset()) != '"') {
+                            // make a phrase out of the synonym
+                            termToAdd = new StringBuilder(termToAdd).insert(0, '"').append('"').toString();
+                        }
+                    }
                     if (!bag) {
                         // create a graph of all possible synonym combinations,
                         // e.g. dog bite, hound bite, dog nibble, hound nibble, etc.
-	                    TextInQuery textInQuery = new TextInQuery(termToAdd, 
-	                            offsetAttribute.startOffset(), 
-	                            offsetAttribute.endOffset());
-	                    
-	                    startPosToTextsInQuery.put(offsetAttribute.startOffset(), textInQuery);
+                        TextInQuery textInQuery = new TextInQuery(termToAdd, offsetAttribute.startOffset(), offsetAttribute.endOffset());
+
+                        startPosToTextsInQuery.put(offsetAttribute.startOffset(), textInQuery);
                     }
                 }
             }
@@ -499,93 +565,79 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
                 throw new RuntimeException("uncaught exception in synonym processing", e);
             }
         }
-               
+
         List<String> alternateQueries = synonymBag;
-        
+
         if (!bag) {
             // use a graph rather than a bag
-	        List<List<TextInQuery>> sortedTextsInQuery = new ArrayList<>(
-                    startPosToTextsInQuery.values().size());
+            List<List<TextInQuery>> sortedTextsInQuery = new ArrayList<>(startPosToTextsInQuery.values().size());
             sortedTextsInQuery.addAll(startPosToTextsInQuery.asMap().values().stream().map(ArrayList::new).collect(Collectors.toList()));
-	        
-	        // have to use the start positions and end positions to figure out all possible combinations
-	        alternateQueries = buildUpAlternateQueries(solrParams, sortedTextsInQuery);
+
+            // have to use the start positions and end positions to figure out all possible combinations
+            alternateQueries = buildUpAlternateQueries(solrParams, sortedTextsInQuery);
         }
-        
+
         // save for debugging purposes
         expandedSynonyms = alternateQueries;
-        
+
         return createSynonymQueries(solrParams, alternateQueries);
     }
 
     /**
-     * From a list of texts in the original query that were deemed to be interested (i.e. synonyms or the original text
-     * itself), build up all possible alternate queries as strings.
-     * 
-     * For instance, if the query is "dog bite" and the synonyms are dog -> [dog,hound,pooch] and bite -> [bite,nibble],
-     * then the result will be:
-     * 
-     * dog bite
-     * hound bite
-     * pooch bite
-     * dog nibble
-     * hound nibble
-     * pooch nibble
+     * From a list of texts in the original query that were deemed to be interested (i.e. synonyms or the original text itself), build up all possible alternate queries as strings. For instance, if the query is "dog bite" and the synonyms are dog -> [dog,hound,pooch] and bite -> [bite,nibble], then the result will be: dog bite hound bite pooch bite dog nibble hound nibble pooch nibble
      * 
      * @param solrParams
      * @param textsInQueryLists
      * @return
      */
     private List<String> buildUpAlternateQueries(SolrParams solrParams, List<List<TextInQuery>> textsInQueryLists) {
-        
+
         String originalUserQuery = getQueryStringFromParser();
-        
+
         if (textsInQueryLists.isEmpty()) {
             return Collections.emptyList();
         }
-        
+
         // initialize results
         List<AlternateQuery> alternateQueries = new ArrayList<>();
         for (TextInQuery textInQuery : textsInQueryLists.get(0)) {
             // add the text before the first user query token, e.g. a space or a "
-            StringBuilder stringBuilder = new StringBuilder(
-                    originalUserQuery.subSequence(0, textInQuery.getStartPosition()))
-                    .append(textInQuery.getText());
+            StringBuilder stringBuilder = new StringBuilder(originalUserQuery.subSequence(0, textInQuery.getStartPosition())).append(textInQuery.getText());
             alternateQueries.add(new AlternateQuery(stringBuilder, textInQuery.getEndPosition()));
         }
-        
+
         for (int i = 1; i < textsInQueryLists.size(); i++) {
             List<TextInQuery> textsInQuery = textsInQueryLists.get(i);
-            
+
             // compute the length in advance, because we'll be adding new ones as we go
             int alternateQueriesLength = alternateQueries.size();
-            
+
             for (int j = 0; j < alternateQueriesLength; j++) {
-                
+
                 // When we're working with a lattice, assuming there's only one path to take in the next column,
                 // we can (and MUST) use all the original objects in the current column.
                 // It's only when we have >1 paths in the next column that we need to start taking copies.
                 // So if a lot of this logic seems tortured, it's only because I'm trying to minimize object
                 // creation.
                 AlternateQuery originalAlternateQuery = alternateQueries.get(j);
-                
+
                 boolean usedFirst = false;
-                
+
                 for (int k = 0; k < textsInQuery.size(); k++) {
-                    
-                    TextInQuery textInQuery =  textsInQuery.get(k);
+
+                    TextInQuery textInQuery = textsInQuery.get(k);
                     if (originalAlternateQuery.getEndPosition() > textInQuery.getStartPosition()) {
                         // cannot be appended, e.g. "canis" token in "canis familiaris"
                         continue;
                     }
-                    
+
                     AlternateQuery currentAlternateQuery;
-                    
+
                     if (!usedFirst) {
                         // re-use the existing object
                         usedFirst = true;
                         currentAlternateQuery = originalAlternateQuery;
-                        
+
                         if (k < textsInQuery.size() - 1) {
                             // make a defensive clone for future usage
                             originalAlternateQuery = (AlternateQuery) currentAlternateQuery.clone();
@@ -600,49 +652,47 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
                         alternateQueries.add(currentAlternateQuery);
                     }
                     // text in the original query between the two tokens, usually a space, comma, etc.
-                    CharSequence betweenTokens = originalUserQuery.subSequence(
-                            currentAlternateQuery.getEndPosition(), textInQuery.getStartPosition());
+                    CharSequence betweenTokens = originalUserQuery.subSequence(currentAlternateQuery.getEndPosition(), textInQuery.getStartPosition());
                     currentAlternateQuery.getStringBuilder().append(betweenTokens).append(textInQuery.getText());
                     currentAlternateQuery.setEndPosition(textInQuery.getEndPosition());
                 }
             }
         }
-        
-        //Make sure result is unique
+
+        // Make sure result is unique
         HashSet<String> result = new LinkedHashSet<>();
-        
+
         for (AlternateQuery alternateQuery : alternateQueries) {
-            
+
             StringBuilder sb = alternateQuery.getStringBuilder();
-            
+
             // append whatever text followed the last token, e.g. '"'
             sb.append(originalUserQuery.subSequence(alternateQuery.getEndPosition(), originalUserQuery.length()));
-            
+
             result.add(sb.toString());
         }
         return new ArrayList<>(result);
     }
-    
+
     /**
-     * From a list of alternate queries in text format, parse them using the default
-     * ExtendedSolrQueryParser and return the queries.
+     * From a list of alternate queries in text format, parse them using the default ExtendedSolrQueryParser and return the queries.
      * 
      * @param solrParams
      * @param alternateQueryTexts
      * @return
      */
     private List<Query> createSynonymQueries(SolrParams solrParams, List<String> alternateQueryTexts) {
-        
+
         String nullsafeOriginalString = getQueryStringFromParser();
-        
+
         List<Query> result = new ArrayList<>();
         for (String alternateQueryText : alternateQueryTexts) {
-            if (alternateQueryText.equalsIgnoreCase(nullsafeOriginalString)) { 
+            if (alternateQueryText.equalsIgnoreCase(nullsafeOriginalString)) {
                 // alternate query is the same as what the user entered
                 continue;
             }
-            
-            synonymQueryParser.setString(alternateQueryText);
+
+            synonymQueryParser.setString(analyzeQuery(alternateQueryText, mainAnalyzer));
             try {
                 result.add(synonymQueryParser.parse());
             } catch (SyntaxError e) {
@@ -650,20 +700,22 @@ class SynonymExpandingExtendedDismaxQParser extends QParser {
                 e.printStackTrace(System.err);
             }
         }
-        
+
         return result;
     }
 
     /**
      * Ensures that we return a valid string, even if null
+     * 
      * @return the entered query string fetched from QParser.getString()
      */
     private String getQueryStringFromParser() {
-      return (getString() == null) ? "" : getString();
+        return (getString() == null) ? "" : getString();
     }
-    
+
     /**
      * Convenience method to simplify code
+     * 
      * @param qparser
      * @return
      */

--- a/src/test/java/com/github/healthonnet/search/TestMultiAnalyzer.java
+++ b/src/test/java/com/github/healthonnet/search/TestMultiAnalyzer.java
@@ -1,0 +1,43 @@
+package com.github.healthonnet.search;
+
+import java.io.IOException;
+
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.BasicResultContext;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Test;
+
+public class TestMultiAnalyzer extends HonLuceneSynonymTestCase {
+
+    public TestMultiAnalyzer() {
+        defaultRequest = new String[] { "qf", "name", "mm", "100%", "synonyms", "true", "defType", "synonym_edismax", "debugQuery", "on" };
+        commitDocs();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void verifyExpectedResults(String query, String expParsedQuery, int NumDoc, String... params) {
+        SolrCore core = h.getCore();
+        try (SolrQueryRequest req = constructRequest(query, params)) {
+            SolrQueryResponse rsp = new SolrQueryResponse();
+            core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
+
+            String parsedQuery = ((NamedList) rsp.getValues().get("debug")).get("parsedquery_toString").toString();
+            int numFound = ((BasicResultContext) rsp.getValues().get("response")).getDocList().matches();
+            assertEquals(expParsedQuery, parsedQuery);
+            assertEquals(NumDoc, numFound);
+
+        }
+    }
+
+    @Test
+    public void multiSynonymsFile() throws IOException {
+        verifyExpectedResults("cat", "+(name:cat)", 0);
+        verifyExpectedResults("cat", "+(name:cat)", 0, "synonyms.analyzer", "myCoolAnalyzer");
+        verifyExpectedResults("cat", "+(((name:cat))^1.0 ((+(name:dog))^1.0))", 1, "synonyms.analyzer", "mySecondAnalyzer");
+
+    }
+
+}

--- a/src/test/java/com/github/healthonnet/search/TestPreanalyzis.java
+++ b/src/test/java/com/github/healthonnet/search/TestPreanalyzis.java
@@ -1,0 +1,44 @@
+package com.github.healthonnet.search;
+
+import java.io.IOException;
+
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.BasicResultContext;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.Test;
+
+public class TestPreanalyzis extends HonLuceneSynonymTestCase {
+
+    public TestPreanalyzis() {
+        defaultRequest = new String[] { "qf", "name", "mm", "100%", "synonyms", "true", "defType", "synonym_edismax", "synonyms.preanalyzis", "true", "debugQuery", "on" };
+        commitDocs();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void verifyExpectedResults(String query, String expecteAnalysis, String expParsedQuery, int NumDoc, String... params) {
+        SolrCore core = h.getCore();
+        try (SolrQueryRequest req = constructRequest(query, params)) {
+            SolrQueryResponse rsp = new SolrQueryResponse();
+            core.execute(core.getRequestHandler(req.getParams().get(CommonParams.QT)), req, rsp);
+
+            String preparsedQuery = ((NamedList) rsp.getValues().get("debug")).get("originalPreparsedQuery").toString();
+            String parsedQuery = ((NamedList) rsp.getValues().get("debug")).get("parsedquery_toString").toString();
+            int numFound = ((BasicResultContext) rsp.getValues().get("response")).getDocList().matches();
+            assertEquals(expecteAnalysis, preparsedQuery);
+            assertEquals(expParsedQuery, parsedQuery);
+            assertEquals(NumDoc, numFound);
+
+        }
+    }
+
+    @Test
+    public void preAnalize() throws IOException {
+        verifyExpectedResults("the dog", "dog", "+(((name:dog))^1.0 ((+(((name:canis) (name:familiaris))~2))^1.0) ((+(name:hound))^1.0) ((+(((name:man's) (name:best) (name:friend))~3))^1.0))", 3, "synonyms.preanalyzer", "mainFirstAnalyzer");
+        verifyExpectedResults("a pooch", "", "MatchNoDocsQuery(\"\")", 0, "synonyms.preanalyzer", "mainFirstAnalyzer");
+        verifyExpectedResults("a dog", "dog", "+(((name:dog))^1.0 ((+(name:familiaris))^1.0) ((+(name:hound))^1.0) ((+(((name:man's) (name:best) (name:friend))~3))^1.0) ((+(name:pooch))^1.0))", 5, "synonyms.preanalyzer", "mainSecondAnalyzer");
+
+    }
+}

--- a/src/test/resources/solr/collection1/conf/example_solrconfig.xml
+++ b/src/test/resources/solr/collection1/conf/example_solrconfig.xml
@@ -23,10 +23,56 @@
   <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
-  <requestHandler name="/search" class="solr.StandardRequestHandler" default="true"/>
+  <requestHandler name="/search" class="solr.StandardRequestHandler" default="true">
+     <lst name="defaults">
+      <str name="synonyms.default">myCoolAnalyzer</str>
+      <str name="synonyms.preanalyzis">false</str>
+     </lst>
+  </requestHandler>
+  
   <requestHandler name="/update" class="solr.UpdateRequestHandler"/>
 
   <queryParser name="synonym_edismax" class="com.github.healthonnet.search.SynonymExpandingExtendedDismaxQParserPlugin">
+   
+    <lst name="queryAnalyzers">
+      <!-- Name your analyzer something useful, e.g. "analyzer_en", "analyzer_fr", "analyzer_es", etc.
+           If you only have one, the name doesn't matter (hence "myCoolAnalyzer").
+        -->
+       <lst name="mainFirstAnalyzer">
+        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
+             This seems to work best with most people's synonym files.
+             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
+          -->
+        <lst name="tokenizer">
+          <str name="class">solr.PatternTokenizerFactory</str>
+          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
+        </lst>
+ 
+        <lst name="filter">
+          <str name="class">solr.StopFilterFactory</str>
+          <str name="words">example_stopwords_file.txt</str>
+          <str name="ignoreCase">true</str>
+         </lst>
+      </lst>
+      
+       <lst name="mainSecondAnalyzer">
+        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
+             This seems to work best with most people's synonym files.
+             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
+          -->
+        <lst name="tokenizer">
+          <str name="class">solr.PatternTokenizerFactory</str>
+          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
+        </lst>
+ 
+        <lst name="filter">
+          <str name="class">solr.StopFilterFactory</str>
+          <str name="words">example_stopwords_file2.txt</str>
+          <str name="ignoreCase">true</str>
+         </lst>
+      </lst>
+    </lst> 
+        
     <!-- You can define more than one synonym analyzer in the following list.
          For example, you might have one set of synonyms for English, one for French,
          one for Spanish, etc.
@@ -67,6 +113,40 @@
           <str name="ignoreCase">true</str>
         </lst>
       </lst>
+      
+      <lst name="mySecondAnalyzer">
+        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
+             This seems to work best with most people's synonym files.
+             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
+          -->
+        <lst name="tokenizer">
+          <str name="class">solr.PatternTokenizerFactory</str>
+          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
+        </lst>
+        <!-- The ShingleFilterFactory outputs synonyms of multiple token lengths (e.g. unigrams, bigrams, trigrams, etc.).
+             The default here is to assume you don't have any synonyms longer than 4 tokens.
+             You can tweak this depending on what your synonyms look like. E.g. if you only have unigrams, you can remove
+             it entirely, and if your synonyms are up to 7 tokens in length, you should set the maxShingleSize to 7.
+          -->
+        <lst name="filter">
+          <str name="class">solr.ShingleFilterFactory</str>
+          <str name="outputUnigramsIfNoShingles">true</str>
+          <str name="outputUnigrams">true</str>
+          <str name="minShingleSize">2</str>
+          <str name="maxShingleSize">4</str>
+        </lst>
+        <!-- This is where you set your synonym file.  For the unit tests and "Getting Started" examples, we use example_synonym_file.txt.
+             This plugin will work best if you keep expand set to true and have all your synonyms comma-separated (rather than =>-separated).
+          -->
+        <lst name="filter">
+          <str name="class">solr.SynonymFilterFactory</str>
+          <str name="tokenizerFactory">solr.KeywordTokenizerFactory</str>
+          <str name="synonyms">example_synonym_file2.txt</str>
+          <str name="expand">true</str>
+          <str name="ignoreCase">true</str>
+        </lst>
+      </lst>
     </lst>
+    
   </queryParser>
 </config>

--- a/src/test/resources/solr/collection1/conf/example_stopwords_file.txt
+++ b/src/test/resources/solr/collection1/conf/example_stopwords_file.txt
@@ -1,0 +1,4 @@
+a
+the
+pooch
+

--- a/src/test/resources/solr/collection1/conf/example_stopwords_file2.txt
+++ b/src/test/resources/solr/collection1/conf/example_stopwords_file2.txt
@@ -1,0 +1,3 @@
+canis
+the
+a

--- a/src/test/resources/solr/collection1/conf/example_synonym_file2.txt
+++ b/src/test/resources/solr/collection1/conf/example_synonym_file2.txt
@@ -1,0 +1,4 @@
+dog,hound,pooch,canis familiaris,man's best friend
+back pack=>backpack
+cat=>dog
+pet=>familiaris


### PR DESCRIPTION
For a project, we use the synomyms-edismax parsed to avoid issues in highlighting with synonyms. It works great! The plugin is able to configured several analyzers for the synonyms part of the query. But, we have the same needs the same behaviour for the main query part. (Precisely, we need to select stopwords files at query time. So, I developped the abilty to configure analyzers on the original query before applying synonyms. By default, no preanalyzis is done on the query for compatibility. I give  an exemple of a new configuration of the plugin in the resource of the test package. I upgraded the tests units with this new functionnality.

