### PR TITLE
Need to handle configoverlay.json created by Solr's ConfigAPI

### DIFF
--- a/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
+++ b/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
@@ -189,10 +189,15 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
                 NamedList<?> synonymAnalyzersList = (NamedList<?>) xmlSynonymAnalyzers;
                 for (Entry<String, ?> entry : synonymAnalyzersList) {
                     String analyzerName = entry.getKey();
-                    if (!(entry.getValue() instanceof NamedList)) {
-                        continue;
-                    }
-                    NamedList<?> analyzerAsNamedList = (NamedList<?>) entry.getValue();
+                    if (!(entry.getValue() instanceof NamedList) && !(entry.getValue() instanceof Map)) {
+            	      continue;
+           	    }
+          	    NamedList<?> analyzerAsNamedList;
+          	    if (entry.getValue() instanceof Map) {
+            	      analyzerAsNamedList = new NamedList((Map) entry.getValue());
+          	    } else {
+            	      analyzerAsNamedList = (NamedList<?>) entry.getValue();
+          	    }
 
                     TokenizerFactory tokenizerFactory = null;
                     TokenFilterFactory filterFactory;
@@ -200,10 +205,15 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
 
                     for (Entry<String, ?> analyzerEntry : analyzerAsNamedList) {
                         String key = analyzerEntry.getKey();
-                        if (!(entry.getValue() instanceof NamedList)) {
-                            continue;
-                        }
-                        Map<String, String> params = convertNamedListToMap((NamedList<?>)analyzerEntry.getValue());
+                        if (!(analyzerEntry.getValue() instanceof NamedList) && !(analyzerEntry.getValue() instanceof Map)) {
+              		  continue;
+            		}
+            		Map<String, String> params;
+            		if (analyzerEntry.getValue() instanceof Map) {
+              		  params = convertTypesToString((Map<String, ?>) analyzerEntry.getValue());
+            		} else {
+              		  params = convertNamedListToMap((NamedList<?>) analyzerEntry.getValue());
+            		}
 
                         String className = params.get("class");
                         if (className == null) {
@@ -225,7 +235,7 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
                             if (tokenizerFactory instanceof ResourceLoaderAware) {
                                 ((ResourceLoaderAware)tokenizerFactory).inform(loader);
                             }
-                        } else if (key.equals("filter")) {
+                        } else if (key.startsWith("filter")) {
                             try {
                                 filterFactory = TokenFilterFactory.forName(className, params);
                             } catch (IllegalArgumentException iae) {
@@ -259,6 +269,34 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
             throw new SolrException(ErrorCode.SERVER_ERROR, "Failed to create parser. Check your config.", e);
         }
     }
+  /**
+   * Converts a Map<String, ?> into a Map<String, String> (used to prevent deep CastException caused by configoverlay.json file)
+   * Handled types are String, Long, Integer & Boolean
+   * @param map the map to convert
+   * @return an empty map if the provided map is null, else apply a toString() on each value
+   */
+  private Map<String, String> convertTypesToString(Map<String, ?> map) {
+    if (map == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> res = new HashMap<>(map.size());
+    map.forEach((k, v) -> {
+      if (v instanceof String) {
+        res.put(k, (String) v);
+      } else if (v instanceof Long) {
+        res.put(k, Long.toString((Long) v));
+      } else if (v instanceof Integer) {
+        res.put(k, Integer.toString((Integer) v));
+      } else if (v instanceof Boolean) {
+        res.put(k, Boolean.toString((Boolean) v));
+      } else {
+        LOG.error("Type of parameter {} with value {} not handle", k, v);
+      }
+    });
+	  
+    return res;
+  }
 }
 
 class SynonymExpandingExtendedDismaxQParser extends QParser {

--- a/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
+++ b/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java
@@ -290,8 +290,6 @@ public class SynonymExpandingExtendedDismaxQParserPlugin extends QParserPlugin i
         res.put(k, Integer.toString((Integer) v));
       } else if (v instanceof Boolean) {
         res.put(k, Boolean.toString((Boolean) v));
-      } else {
-        LOG.error("Type of parameter {} with value {} not handle", k, v);
       }
     });
 	  


### PR DESCRIPTION
I experienced a pretty though to found bug caused by the configoverlay.json file generated when using Solr's ConfigAPI.

Long story short Solr configoverlay.json unmarshalling returns a LinkedHashMap not a NamedList, which makes the [line](https://github.com/healthonnet/hon-lucene-synonyms/blob/c87fb8ced0abc9e19381a4843c964cf8473e8912/src/main/java/com/github/healthonnet/search/SynonymExpandingExtendedDismaxQParserPlugin.java#L192) always true so nothing more happen.

Plus, as the unmarshalling returns a map of type Map<String, Object>, I made a really simple method to do the conversion of main types to String.