### PR TITLE
Synonyms aren't expanded if boost applied in Solr 7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <solr.version>6.2.0</solr.version>
+    <solr.version>7.3.0</solr.version>
     <slf4j.version>1.7.7</slf4j.version>
   </properties>
 	<dependencies>

--- a/src/test/java/com/github/healthonnet/search/HonLuceneSynonymTestCase.java
+++ b/src/test/java/com/github/healthonnet/search/HonLuceneSynonymTestCase.java
@@ -10,7 +10,6 @@ import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.search.DocIterator;
 import org.apache.solr.search.DocList;
 import org.apache.solr.search.DocSlice;
-import org.apache.solr.util.AbstractSolrTestCase;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
@@ -22,7 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @SolrTestCaseJ4.SuppressSSL
-public abstract class HonLuceneSynonymTestCase extends AbstractSolrTestCase {
+public abstract class HonLuceneSynonymTestCase extends SolrTestCaseJ4 {
     String[] defaultRequest = {
             "qf", "name",
             "mm", "100%",

--- a/src/test/java/com/github/healthonnet/search/TestBoostedQuery.java
+++ b/src/test/java/com/github/healthonnet/search/TestBoostedQuery.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.healthonnet.search;
+
+import org.junit.Test;
+
+public class TestBoostedQuery extends HonLuceneSynonymTestCase {
+
+    public TestBoostedQuery() {
+        defaultDocs = new String[][]{
+                {"id", "1", "name", "I have a backpack"},
+                {"id", "2", "name", "I have a back pack"},
+                {"id", "3", "name", "I have a house"},
+                {"id", "4", "name", "I have a car"}
+        };
+        defaultRequest = new String[]{
+                "fl", "*,score",
+                "qf", "name",
+                "defType", "synonym_edismax",
+                "synonyms", "true",
+                "debugQuery", "on",
+                "bf", "10"
+        };
+        commitDocs();
+    }
+
+    @Test
+    public void queries() {
+        assertQuery("back pack", 2); // no boost
+
+        assertQuery("back pack", 2, "boost", "numdocs()"); // boost applied
+
+        assertQuery("back pack", 2, // a combination of boosts applied
+                "boost", "numdocs()",
+                "boost", "recip(ms(NOW/HOUR,last_modified),3.16e-11,1,1)");
+
+        // doc having the term 'back' goes first
+        assertQuery(new String[]{
+                "//result/doc[1]/str[@name='id'][.='2']",
+                "//result/doc[2]/str[@name='id'][.='1']"
+        }, "back pack", 2, "boost", "if(termfreq(name,'back'),1,0)");
+
+        // doc having the term 'backpack' goes first
+        assertQuery(new String[]{
+                "//result/doc[1]/str[@name='id'][.='1']",
+                "//result/doc[2]/str[@name='id'][.='2']"
+        }, "back pack", 2, "boost", "if(termfreq(name,'backpack'),1,0)");
+    }
+
+}


### PR DESCRIPTION
This used to work in Solr 6 but got broken in Solr 7.+
If a boost parameter is specified then synonyms are not expanded. The bug originates from SynonymExpandingExtendedDismaxQParserPlugin#applySynonymQueries which assumes that the input query is either a BoostedQuery or a BooleanQuery :

```
if (query instanceof BoostedQuery) {
  ...
} else if (query instanceof BooleanQuery) {
  ...
}
```

This is no longer the case in Solr 7 where BoostedQuery is deprecated and replaced by FunctionScoreQuery. With this in mind, the code flow in applySynonymQueries becomes

```
if (query instanceof BoostedQuery) {
  ...
} else if (query instanceof FunctionScoreQuery) { 
  FunctionScoreQuery functionScoreQuery = (FunctionScoreQuery) query;
  Query q = applySynonymQueries(functionScoreQuery.getWrappedQuery(), synonymQueries, originalBoost, synonymBoost);
  return new FunctionScoreQuery(q, source);
} else if (query instanceof BooleanQuery) {
  ...
}
```

The idea is to expand the wrapped query and then re-wrap the result. 
The second argument in the constructor of FunctionScoreQuery is DoubleValuesSource. Unfortunately this is a private field without a getter and I found nothing better than to use introspection. This *might* not work in Java 9 and 10 as the semantics of Field#setAccessible changed. I tested with Java 8 and it worked for me.

Regards,
Yegor